### PR TITLE
Refine beta page: replace Judy story, sticky CTA, modern donate button

### DIFF
--- a/public/css/beta.css
+++ b/public/css/beta.css
@@ -113,17 +113,22 @@ a:hover {
 .beta-nav-links a:hover {
   color: var(--rr-red);
 }
-.beta-nav-cta {
+/* Sticky CTA — always visible, outside collapsible menu */
+.beta-nav-sticky-cta {
   background: var(--rr-red);
   color: #fff !important;
   padding: 0.5rem 1.25rem;
   border-radius: 50px;
-  font-size: 0.85rem !important;
-  font-weight: 600 !important;
+  font-size: 0.85rem;
+  font-weight: 600;
   letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
   transition: background 0.2s, transform 0.2s;
 }
-.beta-nav-cta:hover {
+.beta-nav-sticky-cta:hover {
   background: var(--rr-red-dark);
   color: #fff !important;
   transform: translateY(-1px);
@@ -143,6 +148,17 @@ a:hover {
 @media (max-width: 768px) {
   .beta-nav-toggle {
     display: block;
+  }
+  .beta-nav-inner {
+    gap: 0.75rem;
+  }
+  .beta-nav-sticky-cta {
+    font-size: 0.75rem;
+    padding: 0.4rem 1rem;
+    order: 2;
+  }
+  .beta-nav-toggle {
+    order: 3;
   }
   .beta-nav-links {
     display: none;
@@ -530,8 +546,75 @@ a:hover {
   margin: 0;
   line-height: 1.5;
 }
-.paypal-wrap {
+/* Address disclosure inside Donate card */
+.address-disclosure {
+  margin-top: 0.75rem;
+}
+.address-disclosure summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+  list-style: none;
+}
+.address-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+.address-disclosure summary::before {
+  content: '\f078';
+  font-family: 'Font Awesome 6 Free';
+  font-weight: 900;
+  margin-right: 0.4rem;
+  font-size: 0.65rem;
+  transition: transform 0.2s;
+  display: inline-block;
+}
+.address-disclosure[open] summary::before {
+  transform: rotate(180deg);
+}
+.address-disclosure summary:hover {
+  opacity: 1;
+}
+.address-disclosure .address-text {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  opacity: 0.7;
+  line-height: 1.6;
+}
+
+/* Custom donate button */
+.donate-btn-wrap {
   margin-top: 2rem;
+}
+.btn-donate {
+  display: inline-block;
+  background: linear-gradient(135deg, #ff6b6b, var(--rr-red));
+  color: #fff !important;
+  padding: 1rem 3rem;
+  border-radius: 50px;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 4px 20px rgba(192, 57, 43, 0.4);
+}
+.btn-donate:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(192, 57, 43, 0.5);
+  color: #fff !important;
+}
+.btn-donate i {
+  margin-right: 0.4rem;
+}
+.donate-secure-note {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  opacity: 0.5;
+}
+.donate-secure-note i {
+  margin-right: 0.3rem;
 }
 @media (max-width: 768px) {
   .cta-options {

--- a/src/pages/beta/index.astro
+++ b/src/pages/beta/index.astro
@@ -5,8 +5,7 @@ import heroImg from '../../assets/images/fp-hero.jpg';
 import visionImg from '../../assets/images/our-vision-0.jpg';
 import historyImg from '../../assets/images/our-history.jpg';
 import clothesImg from '../../assets/images/2024-p0.jpg';
-import kidsImg from '../../assets/images/2024-p2.jpg';
-import judyImg from '../../assets/images/2019-judy.jpg';
+import schoolImg from '../../assets/images/school-assembly-with-flag.jpg';
 import nutritionImg from '../../assets/images/2019-p1.jpg';
 import dressesImg from '../../assets/images/2018-pillowcasedresses1.jpg';
 import logoImg from '../../assets/images/rrlogo-only.png';
@@ -52,8 +51,8 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
       <li><a href="#vision">Vision</a></li>
       <li><a href="#stories">Stories</a></li>
       <li><a href="#team">Team</a></li>
-      <li><a href="#involved" class="beta-nav-cta">Donate</a></li>
     </ul>
+    <a href="#involved" class="beta-nav-sticky-cta">Get Involved</a>
   </div>
 </nav>
 
@@ -132,7 +131,7 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
       <!-- Scholarships -->
       <div class="campaign-card">
         <div class="campaign-card-img">
-          <Image src={judyImg} alt="Scholarship student Judy" width={500} />
+          <Image src={schoolImg} alt="Students at school assembly" width={500} />
         </div>
         <div class="campaign-card-body">
           <h3>Scholarships</h3>
@@ -230,16 +229,17 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
     <!-- Story 1 -->
     <div class="story-grid" style="margin-bottom:4rem;">
       <div class="story-text">
-        <h3>Judy's Journey</h3>
+        <h3>Sixty Dresses, Sixty Smiles</h3>
         <p>
-          Judy grew up at Mama Ngina Children's Home. With Riva Refuge's
-          support, she completed college and built an independent life.
-          Her sister Noreen followed the same path. Both are now thriving
-          — proof that a hand up at the right time changes everything.
+          In 2018, a generous US volunteer hand-sewed sixty pillowcase
+          dresses for girls in Kitale. What arrived as a suitcase of
+          fabric left as pure joy — each dress a reminder that someone
+          across the world cared. Small acts of kindness, multiplied
+          by dedicated volunteers, create moments that last a lifetime.
         </p>
       </div>
       <div class="story-img">
-        <Image src={kidsImg} alt="Happy children with new clothes" width={500} />
+        <Image src={dressesImg} alt="Girls wearing handmade pillowcase dresses" width={500} />
       </div>
     </div>
 
@@ -275,7 +275,11 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
       <div class="cta-card">
         <div class="cta-card-icon"><i class="fa-solid fa-hand-holding-heart"></i></div>
         <h3>Donate</h3>
-        <p>Give via PayPal online or mail a check to Riva Refuge, Inc., 10 West Bluff Drive, Port Angeles WA 98362.</p>
+        <p>Give securely via PayPal or mail a check.</p>
+        <details class="address-disclosure">
+          <summary>View mailing address</summary>
+          <p class="address-text">Riva Refuge, Inc.<br />10 West Bluff Drive<br />Port Angeles, WA 98362</p>
+        </details>
       </div>
       <div class="cta-card">
         <div class="cta-card-icon"><i class="fa-solid fa-people-group"></i></div>
@@ -289,9 +293,16 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
       </div>
     </div>
 
-    <!-- PayPal Donate Button -->
-    <div class="paypal-wrap">
-      <div id="paypal-donate-button-container"></div>
+    <!-- Donate Button -->
+    <div class="donate-btn-wrap">
+      <a href="https://www.paypal.com/donate/?hosted_button_id=MLN72XRM42EB4"
+         target="_blank" rel="noopener"
+         class="btn-donate">
+        <i class="fa-solid fa-heart"></i> Donate Now
+      </a>
+      <p class="donate-secure-note">
+        <i class="fa-solid fa-lock"></i> Secure payment via PayPal
+      </p>
     </div>
   </div>
 </section>
@@ -372,26 +383,6 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
   });
 </script>
 
-<!-- PayPal Donate SDK -->
-<script is:inline
-  src="https://www.paypalobjects.com/donate/sdk/donate-sdk.js"
-  charset="UTF-8"></script>
-<script is:inline>
-  if (typeof PayPal !== 'undefined') {
-    PayPal.Donation.Button({
-      env: 'production',
-      hosted_button_id: 'MLN72XRM42EB4',
-      onComplete: function () {
-        window.location.href = '/thanks/';
-      },
-      image: {
-        src: 'https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif',
-        alt: 'Donate with PayPal button',
-        title: 'PayPal - The safer, easier way to pay online!',
-      }
-    }).render('#paypal-donate-button-container');
-  }
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
- Replace Judy case study with pillowcase dresses story and swap scholarship card image to school assembly photo
- Move mailing address behind a <details> disclosure in Donate card
- Add always-visible "Get Involved" sticky CTA button in nav bar (persists on mobile alongside hamburger menu)
- Replace PayPal SDK button with custom-styled donate button linking directly to PayPal hosted donation page, removing SDK dependency

https://claude.ai/code/session_01F5GhcBXuU8Q9qNqR6bVUNw