### PR TITLE
Consolidate donate button, reduce board info, fix icons, link Facebook

### DIFF
--- a/public/css/beta.css
+++ b/public/css/beta.css
@@ -582,35 +582,42 @@ a:hover {
   line-height: 1.6;
 }
 
-/* Custom donate button */
-.donate-btn-wrap {
-  margin-top: 2rem;
-}
-.btn-donate {
+/* In-card donate button */
+.btn-donate-card {
   display: inline-block;
   background: linear-gradient(135deg, #ff6b6b, var(--rr-red));
   color: #fff !important;
-  padding: 1rem 3rem;
+  padding: 0.6rem 1.5rem;
   border-radius: 50px;
-  font-size: 1.15rem;
+  font-size: 0.85rem;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   text-decoration: none;
+  margin-top: 0.75rem;
   transition: transform 0.2s, box-shadow 0.2s;
-  box-shadow: 0 4px 20px rgba(192, 57, 43, 0.4);
+  box-shadow: 0 3px 12px rgba(192, 57, 43, 0.3);
 }
-.btn-donate:hover {
+.btn-donate-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 30px rgba(192, 57, 43, 0.5);
+  box-shadow: 0 6px 20px rgba(192, 57, 43, 0.45);
   color: #fff !important;
 }
-.btn-donate i {
-  margin-right: 0.4rem;
+.btn-donate-card i {
+  margin-right: 0.3rem;
+}
+/* Card links (e.g. Facebook) */
+.card-link {
+  color: #ff6b6b !important;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.card-link:hover {
+  color: #fff !important;
 }
 .donate-secure-note {
-  margin-top: 1rem;
-  font-size: 0.8rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
   opacity: 0.5;
 }
 .donate-secure-note i {
@@ -655,6 +662,31 @@ a:hover {
   font-size: 0.85rem;
   color: #888;
   margin: 0;
+}
+.board-disclosure {
+  margin-top: 1.5rem;
+}
+.board-disclosure summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--rr-red);
+  font-weight: 500;
+  list-style: none;
+}
+.board-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+.board-disclosure summary::after {
+  content: ' \25BE';
+  font-size: 0.7rem;
+}
+.board-disclosure[open] summary::after {
+  content: ' \25B4';
+}
+.board-names {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #666;
 }
 
 /* ---------- FOOTER ---------- */

--- a/src/pages/beta/index.astro
+++ b/src/pages/beta/index.astro
@@ -181,28 +181,28 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
         </p>
         <ul class="vision-list" style="margin-top:1.5rem;">
           <li>
-            <div class="vision-icon"><i class="fa-solid fa-briefcase"></i></div>
+            <div class="vision-icon" aria-hidden="true"><i class="fas fa-briefcase"></i></div>
             <div>
               <h4>Economic Opportunity</h4>
               <p>Microloans and small business support</p>
             </div>
           </li>
           <li>
-            <div class="vision-icon"><i class="fa-solid fa-graduation-cap"></i></div>
+            <div class="vision-icon" aria-hidden="true"><i class="fas fa-graduation-cap"></i></div>
             <div>
               <h4>Education</h4>
               <p>Scholarships for disadvantaged students</p>
             </div>
           </li>
           <li>
-            <div class="vision-icon"><i class="fa-solid fa-heart-pulse"></i></div>
+            <div class="vision-icon" aria-hidden="true"><i class="fas fa-medkit"></i></div>
             <div>
               <h4>Health</h4>
               <p>Disease prevention and treatment</p>
             </div>
           </li>
           <li>
-            <div class="vision-icon"><i class="fa-solid fa-children"></i></div>
+            <div class="vision-icon" aria-hidden="true"><i class="fas fa-child"></i></div>
             <div>
               <h4>Children</h4>
               <p>Supporting orphanages and youth programs</p>
@@ -276,6 +276,12 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
         <div class="cta-card-icon"><i class="fa-solid fa-hand-holding-heart"></i></div>
         <h3>Donate</h3>
         <p>Give securely via PayPal or mail a check.</p>
+        <a href="https://www.paypal.com/donate/?hosted_button_id=MLN72XRM42EB4"
+           target="_blank" rel="noopener"
+           class="btn-donate-card">
+          <i class="fa-solid fa-heart"></i> Donate Now
+        </a>
+        <p class="donate-secure-note"><i class="fa-solid fa-lock"></i> Secure via PayPal</p>
         <details class="address-disclosure">
           <summary>View mailing address</summary>
           <p class="address-text">Riva Refuge, Inc.<br />10 West Bluff Drive<br />Port Angeles, WA 98362</p>
@@ -289,21 +295,10 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
       <div class="cta-card">
         <div class="cta-card-icon"><i class="fa-solid fa-share-nodes"></i></div>
         <h3>Spread the Word</h3>
-        <p>Follow us on Facebook and share our mission with your network.</p>
+        <p>Follow us on <a href="https://www.facebook.com/Riva-Refuge-Inc-177593545669926" target="_blank" rel="noopener" class="card-link">Facebook</a> and share our mission with your network.</p>
       </div>
     </div>
 
-    <!-- Donate Button -->
-    <div class="donate-btn-wrap">
-      <a href="https://www.paypal.com/donate/?hosted_button_id=MLN72XRM42EB4"
-         target="_blank" rel="noopener"
-         class="btn-donate">
-        <i class="fa-solid fa-heart"></i> Donate Now
-      </a>
-      <p class="donate-secure-note">
-        <i class="fa-solid fa-lock"></i> Secure payment via PayPal
-      </p>
-    </div>
   </div>
 </section>
 
@@ -319,20 +314,21 @@ const canonicalURL = new URL('/beta/', 'https://www.rivarefuge.org');
     <div class="board-row">
       <div class="board-member">
         <div class="board-member-avatar"><i class="fa-solid fa-user"></i></div>
-        <h4>Lorna VanderZanden</h4>
         <p>President &amp; CEO</p>
       </div>
       <div class="board-member">
         <div class="board-member-avatar"><i class="fa-solid fa-user"></i></div>
-        <h4>Sue Goodwin</h4>
         <p>Vice-President</p>
       </div>
       <div class="board-member">
         <div class="board-member-avatar"><i class="fa-solid fa-user"></i></div>
-        <h4>Marla Taylor</h4>
         <p>Secretary / Treasurer</p>
       </div>
     </div>
+    <details class="board-disclosure">
+      <summary>View board members</summary>
+      <p class="board-names">Lorna VanderZanden, Sue Goodwin, Marla Taylor</p>
+    </details>
   </div>
 </section>
 


### PR DESCRIPTION
- Move Donate Now button and PayPal secure note into the Donate card instead of floating below the grid
- Hide board members' names behind a disclosure; show only roles up front
- Fix vision section icons: swap fa-heart-pulse → fa-medkit and fa-children → fa-child for reliable rendering in FA 6 Free
- Link Facebook group URL in the Spread the Word card

https://claude.ai/code/session_01F5GhcBXuU8Q9qNqR6bVUNw